### PR TITLE
Fix typos and polish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # aptos-book
-The Aptos Book - A one stop reference for Aptos
+The Aptos Book - A one-stop reference for Aptos
 
 ## Setup
 

--- a/src/gas/config.md
+++ b/src/gas/config.md
@@ -23,7 +23,7 @@ Gas unit price is the amount you're willing to pay per gas unit on a transaction
 lower values. When choosing a gas unit price, keep in mind that your account needs enough APT to pay for the entire max
 gas amount times the gas unit price.
 
-Range: 100 - ??? (TOOD: put number or how to get it from gas config)
+Range: 100 - ??? (TODO: put number or how to get it from gas config)
 
 ## Gas Config
 

--- a/src/getting_started/hello_blockchain.md
+++ b/src/getting_started/hello_blockchain.md
@@ -33,7 +33,7 @@ hello_blockchain
 Then, the run next command to simply build and publish the contract:
 
 ```sh
-aptos move publish --profile tutorial --named-addresses hello_blockhain=tutorial
+aptos move publish --profile tutorial --named-addresses hello_blockchain=tutorial
 ```
 
 > Note that `named-addresses` sets the named address `hello_blockchain` in the `Move.toml` file to

--- a/src/guessing_game/testing.md
+++ b/src/guessing_game/testing.md
@@ -108,7 +108,7 @@ module module_addr::guessing_game {
 ## Testing failures
 
 Failures can similarly be tested, by checking for abort codes. These can be added by adding the
-`#[exepcted_failure(abort_code = ...)]`.
+`#[expected_failure(abort_code = ...)]`.
 
 > Note that the abort code can either be a constant e.g. `E_ALREADY_GUESSED` or the number directly `5`.
 

--- a/src/test_files/move_test.md
+++ b/src/test_files/move_test.md
@@ -14,7 +14,7 @@ module module_addr::test_module {
     use aptos_framework::primary_fungible_store;
     use aptos_framework::timestamp;
 
-    /// The lookup to object for escrow in an easily addressible spot
+    /// The lookup to object for escrow in an easily addressable spot
     ///
     /// The main purpose here is to provide fully removable types to allow for full recovery of storage refunds, and not
     /// have a duplicate object.


### PR DESCRIPTION
## Summary
- Fix typo in `expected_failure` attribute example
- Correct misspellings in gas config and Move test modules
- Improve README tagline and hello_blockchain tutorial command

## Testing
- `typos README.md src`
- `mdbook build` *(fails: missing `mdbook-linkcheck` backend)*

------
https://chatgpt.com/codex/tasks/task_b_68968a561e1083209bcf860b365ba49f