### PR TITLE
Add Block-STM animation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -60,6 +60,7 @@
 - [Parallelization](parallelization/intro.md)
     - [Parallelization Basics](parallelization/basics.md)
     - [Parallelization Considerations](parallelization/considerations.md)
+    - [Block-STM](parallelization/blockstm.md)
 - [Design Patterns](design_patterns/intro.md)
     - [Account Authorization by Signer](design_patterns/account_authorization_by_signer.md)
     - [Event Emission](design_patterns/event_emission.md)

--- a/src/parallelization/blockstm-animation.svg
+++ b/src/parallelization/blockstm-animation.svg
@@ -1,24 +1,266 @@
-<svg width="500" height="180" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 520" width="820" height="520">
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748b"/>
+    </marker>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#334155"/>
+    </linearGradient>
+    <linearGradient id="commitGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#16a34a"/>
+    </linearGradient>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="116%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
   <style>
-    .label { font: 14px sans-serif; }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.6; } }
+
+    .title     { font: bold 18px 'Segoe UI', system-ui, sans-serif; fill: #f8fafc; }
+    .subtitle  { font: 13px 'Segoe UI', system-ui, sans-serif; fill: #94a3b8; }
+    .colHead   { font: bold 13px 'Segoe UI', system-ui, sans-serif; fill: #475569; text-anchor: middle; }
+    .txLabel   { font: bold 12px 'Segoe UI Mono', 'SF Mono', monospace; fill: #fff; text-anchor: middle; dominant-baseline: central; }
+    .stageLabel{ font: 11px 'Segoe UI', system-ui, sans-serif; fill: #94a3b8; text-anchor: middle; }
+    .timeLabel { font: 10px 'Segoe UI', system-ui, sans-serif; fill: #64748b; text-anchor: middle; }
+    .legend    { font: 11px 'Segoe UI', system-ui, sans-serif; fill: #475569; }
+    .conflictX { font: bold 16px 'Segoe UI', system-ui, sans-serif; fill: #ef4444; text-anchor: middle; dominant-baseline: central; }
+    .note      { font: italic 11px 'Segoe UI', system-ui, sans-serif; fill: #64748b; }
   </style>
-  <text x="10" y="15" class="label">Speculative Execution</text>
-  <text x="180" y="15" class="label">Validation</text>
-  <text x="340" y="15" class="label">Commit</text>
 
-  <rect id="tx1" x="10" y="30" width="100" height="30" fill="#4CAF50">
-    <animate attributeName="x" values="10;180;340" keyTimes="0;0.5;1" dur="6s" fill="freeze" />
-  </rect>
-  <text x="15" y="50" class="label">Tx1</text>
+  <!-- Background -->
+  <rect width="820" height="520" rx="12" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
 
-  <rect id="tx2" x="10" y="80" width="100" height="30" fill="#2196F3">
-    <animate attributeName="x" values="10;180;10;180;340" keyTimes="0;0.33;0.40;0.73;1" dur="6s" fill="freeze" />
-    <animate attributeName="fill" values="#2196F3;#2196F3;#f44336;#f44336;#2196F3" keyTimes="0;0.33;0.40;0.73;1" dur="6s" fill="freeze" />
-  </rect>
-  <text x="15" y="100" class="label">Tx2</text>
+  <!-- Header bar -->
+  <rect width="820" height="56" rx="12" fill="url(#headerGrad)"/>
+  <rect y="44" width="820" height="12" fill="url(#headerGrad)"/>
+  <text x="24" y="30" class="title">Block-STM  Parallel Execution Pipeline</text>
+  <text x="24" y="46" class="subtitle">Optimistic execution → Validation → Re-execution on conflict → Commit</text>
 
-  <rect id="tx3" x="10" y="130" width="100" height="30" fill="#FFC107">
-    <animate attributeName="x" values="10;180;340" keyTimes="0;0.5;1" dur="6s" fill="freeze" />
-  </rect>
-  <text x="15" y="150" class="label">Tx3</text>
+  <!-- Phase column headers -->
+  <g transform="translate(0,72)">
+    <rect x="130" y="0" width="140" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+    <text x="200" y="18" class="colHead" fill="#2563eb">Execute</text>
+
+    <rect x="290" y="0" width="140" height="28" rx="6" fill="#fefce8" stroke="#fde68a" stroke-width="1"/>
+    <text x="360" y="18" class="colHead" fill="#a16207">Validate</text>
+
+    <rect x="450" y="0" width="140" height="28" rx="6" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+    <text x="520" y="18" class="colHead" fill="#dc2626">Re-execute</text>
+
+    <rect x="610" y="0" width="140" height="28" rx="6" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+    <text x="680" y="18" class="colHead" fill="#16a34a">Commit</text>
+  </g>
+
+  <!-- Timeline axis -->
+  <line x1="130" y1="112" x2="770" y2="112" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="80" y="116" class="timeLabel">Time →</text>
+
+  <!-- ═══════════════ Tx 1: clean pass ═══════════════ -->
+  <g>
+    <text x="50" y="152" font-size="13" font-family="'Segoe UI Mono', monospace" font-weight="bold" fill="#1e293b" text-anchor="middle">Tx 1</text>
+
+    <!-- Execute phase -->
+    <rect x="140" y="136" rx="6" ry="6" width="0" height="30" fill="#3b82f6" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="0.3s" dur="0.6s" fill="freeze"/>
+    </rect>
+    <text x="200" y="152" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="0.6s" dur="0.3s" fill="freeze"/>
+      exec
+    </text>
+
+    <!-- Validate phase -->
+    <rect x="290" y="136" rx="6" ry="6" width="0" height="30" fill="#eab308" filter="url(#shadow)">
+      <animate attributeName="width" values="0;100" begin="1.2s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="340" y="152" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="1.5s" dur="0.3s" fill="freeze"/>
+      valid ✓
+    </text>
+
+    <!-- Commit -->
+    <rect x="620" y="136" rx="6" ry="6" width="0" height="30" fill="url(#commitGrad)" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="2.0s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="680" y="152" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="2.3s" dur="0.3s" fill="freeze"/>
+      commit
+    </text>
+  </g>
+
+  <!-- ═══════════════ Tx 2: conflict → re-execute ═══════════════ -->
+  <g>
+    <text x="50" y="212" font-size="13" font-family="'Segoe UI Mono', monospace" font-weight="bold" fill="#1e293b" text-anchor="middle">Tx 2</text>
+
+    <!-- Execute phase (speculative) -->
+    <rect x="160" y="196" rx="6" ry="6" width="0" height="30" fill="#3b82f6" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="0.5s" dur="0.6s" fill="freeze"/>
+    </rect>
+    <text x="220" y="212" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="0.8s" dur="0.3s" fill="freeze"/>
+      exec
+    </text>
+
+    <!-- Validate phase – fails -->
+    <rect x="300" y="196" rx="6" ry="6" width="0" height="30" fill="#fbbf24" filter="url(#shadow)">
+      <animate attributeName="width" values="0;100" begin="1.4s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="350" y="212" class="txLabel" opacity="0" fill="#fff">
+      <animate attributeName="opacity" values="0;1" begin="1.7s" dur="0.3s" fill="freeze"/>
+      conflict
+    </text>
+    <!-- Conflict X marker -->
+    <text x="410" y="212" class="conflictX" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0.4;1" begin="1.9s" dur="1s" fill="freeze"/>
+      ✗
+    </text>
+
+    <!-- Re-execute phase -->
+    <rect x="460" y="196" rx="6" ry="6" width="0" height="30" fill="#f97316" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="2.8s" dur="0.6s" fill="freeze"/>
+    </rect>
+    <text x="520" y="212" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="3.1s" dur="0.3s" fill="freeze"/>
+      re-exec
+    </text>
+
+    <!-- Commit -->
+    <rect x="620" y="196" rx="6" ry="6" width="0" height="30" fill="url(#commitGrad)" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="3.8s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="680" y="212" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="4.1s" dur="0.3s" fill="freeze"/>
+      commit
+    </text>
+  </g>
+
+  <!-- ═══════════════ Tx 3: clean pass (parallel) ═══════════════ -->
+  <g>
+    <text x="50" y="272" font-size="13" font-family="'Segoe UI Mono', monospace" font-weight="bold" fill="#1e293b" text-anchor="middle">Tx 3</text>
+
+    <!-- Execute -->
+    <rect x="140" y="256" rx="6" ry="6" width="0" height="30" fill="#3b82f6" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="0.4s" dur="0.6s" fill="freeze"/>
+    </rect>
+    <text x="200" y="272" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="0.7s" dur="0.3s" fill="freeze"/>
+      exec
+    </text>
+
+    <!-- Validate -->
+    <rect x="290" y="256" rx="6" ry="6" width="0" height="30" fill="#eab308" filter="url(#shadow)">
+      <animate attributeName="width" values="0;100" begin="1.3s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="340" y="272" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="1.6s" dur="0.3s" fill="freeze"/>
+      valid ✓
+    </text>
+
+    <!-- Commit -->
+    <rect x="620" y="256" rx="6" ry="6" width="0" height="30" fill="url(#commitGrad)" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="2.2s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="680" y="272" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="2.5s" dur="0.3s" fill="freeze"/>
+      commit
+    </text>
+  </g>
+
+  <!-- ═══════════════ Tx 4: clean pass (parallel) ═══════════════ -->
+  <g>
+    <text x="50" y="332" font-size="13" font-family="'Segoe UI Mono', monospace" font-weight="bold" fill="#1e293b" text-anchor="middle">Tx 4</text>
+
+    <!-- Execute -->
+    <rect x="180" y="316" rx="6" ry="6" width="0" height="30" fill="#3b82f6" filter="url(#shadow)">
+      <animate attributeName="width" values="0;100" begin="0.6s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="230" y="332" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="0.9s" dur="0.3s" fill="freeze"/>
+      exec
+    </text>
+
+    <!-- Validate -->
+    <rect x="310" y="316" rx="6" ry="6" width="0" height="30" fill="#eab308" filter="url(#shadow)">
+      <animate attributeName="width" values="0;80" begin="1.5s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="350" y="332" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="1.8s" dur="0.3s" fill="freeze"/>
+      valid ✓
+    </text>
+
+    <!-- Commit -->
+    <rect x="620" y="316" rx="6" ry="6" width="0" height="30" fill="url(#commitGrad)" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="4.5s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="680" y="332" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="4.8s" dur="0.3s" fill="freeze"/>
+      commit
+    </text>
+  </g>
+
+  <!-- ═══════════════ Tx 5: clean pass ═══════════════ -->
+  <g>
+    <text x="50" y="392" font-size="13" font-family="'Segoe UI Mono', monospace" font-weight="bold" fill="#1e293b" text-anchor="middle">Tx 5</text>
+
+    <!-- Execute -->
+    <rect x="160" y="376" rx="6" ry="6" width="0" height="30" fill="#3b82f6" filter="url(#shadow)">
+      <animate attributeName="width" values="0;110" begin="0.7s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="215" y="392" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="1.0s" dur="0.3s" fill="freeze"/>
+      exec
+    </text>
+
+    <!-- Validate -->
+    <rect x="300" y="376" rx="6" ry="6" width="0" height="30" fill="#eab308" filter="url(#shadow)">
+      <animate attributeName="width" values="0;90" begin="1.5s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="345" y="392" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="1.8s" dur="0.3s" fill="freeze"/>
+      valid ✓
+    </text>
+
+    <!-- Commit -->
+    <rect x="620" y="376" rx="6" ry="6" width="0" height="30" fill="url(#commitGrad)" filter="url(#shadow)">
+      <animate attributeName="width" values="0;120" begin="5.2s" dur="0.5s" fill="freeze"/>
+    </rect>
+    <text x="680" y="392" class="txLabel" opacity="0">
+      <animate attributeName="opacity" values="0;1" begin="5.5s" dur="0.3s" fill="freeze"/>
+      commit
+    </text>
+  </g>
+
+  <!-- Dashed vertical separator lines for phase columns -->
+  <line x1="280" y1="100" x2="280" y2="420" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,4"/>
+  <line x1="440" y1="100" x2="440" y2="420" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,4"/>
+  <line x1="600" y1="100" x2="600" y2="420" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,4"/>
+
+  <!-- Conflict arrow from Tx2 validate back to re-execute -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" begin="2.4s" dur="0.5s" fill="freeze"/>
+    <path d="M 400,226 C 400,250 430,250 460,226" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arrowhead)"/>
+    <text x="430" y="252" class="note" text-anchor="middle" fill="#ef4444">read-set invalidated</text>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(24, 440)">
+    <rect x="0" y="0" width="772" height="60" rx="8" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"/>
+
+    <rect x="16" y="14" width="30" height="14" rx="4" fill="#3b82f6"/>
+    <text x="52" y="25" class="legend">Speculative execution</text>
+
+    <rect x="200" y="14" width="30" height="14" rx="4" fill="#eab308"/>
+    <text x="236" y="25" class="legend">Validation</text>
+
+    <rect x="340" y="14" width="30" height="14" rx="4" fill="#f97316"/>
+    <text x="376" y="25" class="legend">Re-execution (after conflict)</text>
+
+    <rect x="570" y="14" width="30" height="14" rx="4" fill="#22c55e"/>
+    <text x="606" y="25" class="legend">Commit</text>
+
+    <text x="16" y="48" class="note">Transactions run in parallel across threads. Conflicts are detected during validation; only conflicting transactions re-execute.</text>
+  </g>
 </svg>

--- a/src/parallelization/blockstm-animation.svg
+++ b/src/parallelization/blockstm-animation.svg
@@ -1,0 +1,24 @@
+<svg width="500" height="180" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .label { font: 14px sans-serif; }
+  </style>
+  <text x="10" y="15" class="label">Speculative Execution</text>
+  <text x="180" y="15" class="label">Validation</text>
+  <text x="340" y="15" class="label">Commit</text>
+
+  <rect id="tx1" x="10" y="30" width="100" height="30" fill="#4CAF50">
+    <animate attributeName="x" values="10;180;340" keyTimes="0;0.5;1" dur="6s" fill="freeze" />
+  </rect>
+  <text x="15" y="50" class="label">Tx1</text>
+
+  <rect id="tx2" x="10" y="80" width="100" height="30" fill="#2196F3">
+    <animate attributeName="x" values="10;180;10;180;340" keyTimes="0;0.33;0.40;0.73;1" dur="6s" fill="freeze" />
+    <animate attributeName="fill" values="#2196F3;#2196F3;#f44336;#f44336;#2196F3" keyTimes="0;0.33;0.40;0.73;1" dur="6s" fill="freeze" />
+  </rect>
+  <text x="15" y="100" class="label">Tx2</text>
+
+  <rect id="tx3" x="10" y="130" width="100" height="30" fill="#FFC107">
+    <animate attributeName="x" values="10;180;340" keyTimes="0;0.5;1" dur="6s" fill="freeze" />
+  </rect>
+  <text x="15" y="150" class="label">Tx3</text>
+</svg>

--- a/src/parallelization/blockstm.md
+++ b/src/parallelization/blockstm.md
@@ -1,11 +1,44 @@
 # Block-STM
 
-Block-STM is an optimistic parallel execution engine that runs transactions speculatively, validates their read and write sets, and re-executes only the ones that conflict. This approach enables high throughput for the Aptos blockchain by keeping cores busy while preserving deterministic results.
+Block-STM is an optimistic parallel execution engine developed by Aptos Labs. It
+runs transactions speculatively across multiple threads, validates their read and
+write sets, and re-executes only the ones whose reads were invalidated by an
+earlier transaction's writes. This approach keeps all available CPU cores busy
+while still producing deterministic, serializable results identical to sequential
+execution.
 
-![Animated view of Block-STM](./blockstm-animation.svg)
+## How It Works
+
+1. **Speculative Execution** — All transactions in a block are dispatched to
+   worker threads in parallel. Each transaction optimistically reads the latest
+   committed values and records its read-set and write-set.
+2. **Validation** — After execution, the scheduler checks whether any value the
+   transaction read has since been overwritten by a lower-indexed transaction.
+   If the read-set is still consistent, validation passes.
+3. **Re-execution** — When validation fails (a *conflict*), the transaction is
+   re-executed with the updated values. Only conflicting transactions pay this
+   cost; the rest proceed to commit.
+4. **Commit** — Validated transactions commit in the original block order,
+   ensuring deterministic output regardless of how threads were scheduled.
+
+The animation below illustrates five transactions flowing through these stages.
+**Tx 2** experiences a conflict during validation (its read-set was invalidated
+by Tx 1's writes), so it re-executes before committing.
+
+![Animated view of Block-STM parallel execution pipeline](./blockstm-animation.svg)
+
+## Why It Matters
+
+In workloads where most transactions touch different state (e.g., independent
+token transfers), nearly all transactions validate on the first attempt and the
+block executes in close to wall-clock time of a single transaction. Even under
+contention, Block-STM gracefully falls back toward sequential performance rather
+than producing incorrect results. This makes it one of the key reasons Aptos
+achieves high throughput — over **160,000 transactions per second** in
+benchmarks.
 
 ## References
 
 - [Block-STM: How We Execute Over 160k Transactions Per Second on the Aptos Blockchain](https://medium.com/aptoslabs/block-stm-how-we-execute-over-160k-transactions-per-second-on-the-aptos-blockchain-3b003657e4ba)
 - [Block-STM blog article](https://blog.chain.link/block-stm/)
-- [Block-STM research paper](https://arxiv.org/abs/2203.06871)
+- [Block-STM research paper (arXiv)](https://arxiv.org/abs/2203.06871)

--- a/src/parallelization/blockstm.md
+++ b/src/parallelization/blockstm.md
@@ -1,0 +1,11 @@
+# Block-STM
+
+Block-STM is an optimistic parallel execution engine that runs transactions speculatively, validates their read and write sets, and re-executes only the ones that conflict. This approach enables high throughput for the Aptos blockchain by keeping cores busy while preserving deterministic results.
+
+![Animated view of Block-STM](./blockstm-animation.svg)
+
+## References
+
+- [Block-STM: How We Execute Over 160k Transactions Per Second on the Aptos Blockchain](https://medium.com/aptoslabs/block-stm-how-we-execute-over-160k-transactions-per-second-on-the-aptos-blockchain-3b003657e4ba)
+- [Block-STM blog article](https://blog.chain.link/block-stm/)
+- [Block-STM research paper](https://arxiv.org/abs/2203.06871)


### PR DESCRIPTION
## Summary
- add animated SVG illustrating Block-STM transaction execution
- document Block-STM with references to external articles and paper
- include new Block-STM chapter in the concurrency section

## Testing
- `mdbook build` *(fails: `mdbook-linkcheck` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6896bc052dbc83208a0c646e4f9926eb