### PR TITLE
docs: add structs and enums guidance

### DIFF
--- a/src/enums/defining.md
+++ b/src/enums/defining.md
@@ -1,1 +1,21 @@
 # Defining Enums
+
+An enum lists its possible variants inside curly braces. The enum may also declare abilities just like a struct:
+
+```move
+enum Status has copy, drop {
+    Success(u64),
+    Error { code: u64, message: vector<u8> },
+    Pending,
+}
+```
+
+Each variant is constructed by name, using either tuple-style or struct-style syntax:
+
+```move
+let s1 = Status::Success(100);
+let s2 = Status::Error { code: 7, message: b"failed".to_vec() };
+let s3 = Status::Pending;
+```
+
+All variants of an enum share the same abilities. The abilities must be supported by the fields carried in every variant.

--- a/src/enums/example.md
+++ b/src/enums/example.md
@@ -1,1 +1,21 @@
 # Example Program Using Enums
+
+```move
+module examples::orders {
+    enum OrderStatus has copy, drop {
+        Open,
+        Filled { qty: u64 },
+        Cancelled,
+    }
+
+    public fun process(status: OrderStatus): u64 {
+        match status {
+            OrderStatus::Open => 0,
+            OrderStatus::Filled { qty } => qty,
+            OrderStatus::Cancelled => 0,
+        }
+    }
+}
+```
+
+Adding a new variant to `OrderStatus` later will cause the `match` in `process` to stop compiling until the new case is handled, making this pattern helpful for safely upgrading modules.

--- a/src/enums/intro.md
+++ b/src/enums/intro.md
@@ -1,1 +1,3 @@
 # Enums and Pattern Matching
+
+Move's `enum` type lets you define a value that can be one of several named variants. Each variant may carry different data, and pattern matching provides a concise way to handle each case.

--- a/src/enums/pattern_matching.md
+++ b/src/enums/pattern_matching.md
@@ -1,1 +1,15 @@
 # Pattern Matching with Enums
+
+Pattern matching lets you branch on the variant of an enum and bind any inner values in a single expression:
+
+```move
+fun describe(status: Status): vector<u8> {
+    match status {
+        Status::Success(v) => b"ok".to_vec(),
+        Status::Error { code, message } => message,
+        Status::Pending => b"pending".to_vec(),
+    }
+}
+```
+
+Matches must be *exhaustive*—every variant is handled. This trait aids upgradability. If a new variant is later added to `Status`, existing `match` expressions that do not include a wildcard arm like `_ =>` will fail to compile, drawing attention to the new case and ensuring the code is updated accordingly.

--- a/src/enums/pattern_matching.md
+++ b/src/enums/pattern_matching.md
@@ -7,7 +7,9 @@ fun describe(status: Status): vector<u8> {
     match status {
         Status::Success(_) => b"ok".to_vec(),
         Status::Error { code, message } => message,
-        Status::Pending => b"pending".to_vec(),
+        Status::Success(v) => b"ok",
+        Status::Error { code, message } => message,
+        Status::Pending => b"pending",
     }
 }
 ```

--- a/src/enums/pattern_matching.md
+++ b/src/enums/pattern_matching.md
@@ -5,7 +5,7 @@ Pattern matching lets you branch on the variant of an enum and bind any inner va
 ```move
 fun describe(status: Status): vector<u8> {
     match status {
-        Status::Success(v) => b"ok".to_vec(),
+        Status::Success(_) => b"ok".to_vec(),
         Status::Error { code, message } => message,
         Status::Pending => b"pending".to_vec(),
     }

--- a/src/structs/abilities.md
+++ b/src/structs/abilities.md
@@ -1,11 +1,11 @@
 # Structs and Abilities
 
-Abilities describe what operations are permitted on a value. Move defines four abilities:
+Abilities describe what operations are permitted on a type. Move defines four abilities:
 
-* `copy` – the value can be duplicated with the `copy` keyword.
-* `drop` – the value can be discarded without being fully used.
-* `store` – the value may be written to global storage.
-* `key` – the value serves as a top-level resource in storage.
+* `copy` – the value can be duplicated implicitly or explicitly copied with the `copy` keyword.
+* `drop` – the value can be discarded without being returned or stored in global storage.
+* `store` – the value may be stored in another struct or enum. 
+* `key` – the value serves as a top-level resource in global storage.  It also defines if a type can be used as a key in a table.
 
 A struct lists the abilities it supports after the `has` keyword:
 
@@ -13,6 +13,6 @@ A struct lists the abilities it supports after the `has` keyword:
 struct Balance has key, store { amount: u64 }
 ```
 
-This declaration means that `Balance` can live in global storage as a resource and can be read or written. Because it lacks `copy` and `drop`, values of `Balance` must be moved or explicitly destroyed.
+This declaration means that `Balance` can live in global storage as a resource and can be read or written. Because it lacks `copy` and `drop`, values of `Balance` must be moved or explicitly destroyed.  It can also be put inside another struct.
 
-If a struct has fields that do not have a particular ability, the struct cannot declare that ability. For example, if one field lacks `copy`, the containing struct also lacks `copy`.
+If a struct has fields that do not have a particular ability, the struct cannot declare that ability. For example, if one field lacks `copy`, the containing struct also lacks `copy` and will fail at compilation time.

--- a/src/structs/abilities.md
+++ b/src/structs/abilities.md
@@ -1,1 +1,18 @@
 # Structs and Abilities
+
+Abilities describe what operations are permitted on a value. Move defines four abilities:
+
+* `copy` – the value can be duplicated with the `copy` keyword.
+* `drop` – the value can be discarded without being fully used.
+* `store` – the value may be written to global storage.
+* `key` – the value serves as a top-level resource in storage.
+
+A struct lists the abilities it supports after the `has` keyword:
+
+```move
+struct Balance has key, store { amount: u64 }
+```
+
+This declaration means that `Balance` can live in global storage as a resource and can be read or written. Because it lacks `copy` and `drop`, values of `Balance` must be moved or explicitly destroyed.
+
+If a struct has fields that do not have a particular ability, the struct cannot declare that ability. For example, if one field lacks `copy`, the containing struct also lacks `copy`.

--- a/src/structs/basics.md
+++ b/src/structs/basics.md
@@ -1,1 +1,41 @@
-# Struct Basics
+# Defining and Instantiating Structs
+
+A struct definition lists its name, any abilities it supports, and its fields:
+
+```move
+module examples::points {
+    /// A simple struct representing a point in 2D space
+    struct Point has copy, drop {
+        x: u64,
+        y: u64,
+    }
+}
+```
+
+The `has` clause declares the abilities a value of `Point` possesses. A struct may only declare abilities that all of its fields also possess.
+
+Instantiate a struct by providing values for each field in order:
+
+```move
+let p = Point { x: 1, y: 2 };
+```
+
+Move supports *deconstruction* to pull a struct back apart. This moves the fields out of the value:
+
+```move
+let Point { x, y } = p; // `p` is now consumed
+```
+
+If the struct has the `copy` ability, deconstruction can copy the value instead of moving it:
+
+```move
+let Point { x, y } = copy p; // `p` remains usable
+```
+
+Deconstruction can also rename fields:
+
+```move
+let Point { x: x0, y: y0 } = p;
+```
+
+These patterns allow you to build and manipulate structured data naturally in Move.

--- a/src/structs/basics.md
+++ b/src/structs/basics.md
@@ -14,13 +14,13 @@ module examples::points {
 
 The `has` clause declares the abilities a value of `Point` possesses. A struct may only declare abilities that all of its fields also possess.
 
-Instantiate a struct by providing values for each field in order:
+Instantiate a struct by providing values for every field in any order:
 
 ```move
 let p = Point { x: 1, y: 2 };
 ```
 
-Move supports *deconstruction* to pull a struct back apart. This moves the fields out of the value:
+Move supports *deconstruction* to pull a struct back apart. This moves the fields out of the struct:
 
 ```move
 let Point { x, y } = p; // `p` is now consumed
@@ -29,7 +29,7 @@ let Point { x, y } = p; // `p` is now consumed
 If the struct has the `copy` ability, deconstruction can copy the value instead of moving it:
 
 ```move
-let Point { x, y } = copy p; // `p` remains usable
+let Point { x, y } = p; // `p` remains usable
 ```
 
 Deconstruction can also rename fields:

--- a/src/structs/example.md
+++ b/src/structs/example.md
@@ -23,7 +23,7 @@ module examples::wallet {
 
     /// Withdraw coins using deconstruction and reconstruction
     public fun withdraw(account: &signer, amount: u64) acquires Wallet {
-        let wallet = borrow_global_mut<Wallet>(signer::address_of(account));
+        let wallet = &mut Wallet[signer::address_of(account)];
         let Balance { amount: bal } = wallet.balance; // deconstruct
         assert!(bal >= amount, 1);
         wallet.balance = Balance { amount: bal - amount }; // reconstruct

--- a/src/structs/example.md
+++ b/src/structs/example.md
@@ -17,7 +17,7 @@ module examples::wallet {
 
     /// Add coins to the wallet
     public fun deposit(account: &signer, amount: u64) acquires Wallet {
-        let wallet = borrow_global_mut<Wallet>(signer::address_of(account));
+        let wallet = &mut Wallet[signer::address_of(account)];
         wallet.balance.amount = wallet.balance.amount + amount;
     }
 

--- a/src/structs/example.md
+++ b/src/structs/example.md
@@ -21,7 +21,7 @@ module examples::wallet {
         wallet.balance.amount = wallet.balance.amount + amount;
     }
 
-    /// Withdraw coins using deconstruction and reconstruction
+    /// Withdraw coins using deconstruction and reconstruction note that this is unnecessary, but used for an example
     public fun withdraw(account: &signer, amount: u64) acquires Wallet {
         let wallet = &mut Wallet[signer::address_of(account)];
         let Balance { amount: bal } = wallet.balance; // deconstruct

--- a/src/structs/example.md
+++ b/src/structs/example.md
@@ -1,1 +1,34 @@
 # Example Program Using Structs
+
+```move
+module examples::wallet {
+    #[resource_group]
+    struct Wallet has key {
+        balance: Balance,
+    }
+
+    #[resource_group_member(group = Wallet)]
+    struct Balance has key { amount: u64 }
+
+    /// Create an empty wallet resource under the signer
+    public fun create(account: &signer) {
+        move_to(account, Wallet { balance: Balance { amount: 0 } });
+    }
+
+    /// Add coins to the wallet
+    public fun deposit(account: &signer, amount: u64) acquires Wallet {
+        let wallet = borrow_global_mut<Wallet>(signer::address_of(account));
+        wallet.balance.amount = wallet.balance.amount + amount;
+    }
+
+    /// Withdraw coins using deconstruction and reconstruction
+    public fun withdraw(account: &signer, amount: u64) acquires Wallet {
+        let wallet = borrow_global_mut<Wallet>(signer::address_of(account));
+        let Balance { amount: bal } = wallet.balance; // deconstruct
+        assert!(bal >= amount, 1);
+        wallet.balance = Balance { amount: bal - amount }; // reconstruct
+    }
+}
+```
+
+This module shows struct definition, grouping with annotations, and how construction and deconstruction work when modifying a resource.

--- a/src/structs/example.md
+++ b/src/structs/example.md
@@ -8,7 +8,7 @@ module examples::wallet {
     }
 
     #[resource_group_member(group = Wallet)]
-    struct Balance has key { amount: u64 }
+    struct Balance has store { amount: u64 }
 
     /// Create an empty wallet resource under the signer
     public fun create(account: &signer) {

--- a/src/structs/intro.md
+++ b/src/structs/intro.md
@@ -1,5 +1,5 @@
 # Using Structs to Structure Related Data
 
-In Move, a `struct` groups related fields into a single type. Structs are the primary way to define custom data types and to model both ephemeral values and on-chain resources. Each struct definition lives inside a module and is either published on-chain or used purely off-chain.
+In Move, a `struct` groups related fields into a single type. Structs are the primary way to define custom data types and to model both ephemeral values and on-chain resources. Each struct definition lives inside a module and is published on-chain.
 
 The following sections cover how to define structs, how abilities affect their behavior, how annotations group resources, and how to construct and deconstruct values.

--- a/src/structs/intro.md
+++ b/src/structs/intro.md
@@ -1,1 +1,5 @@
 # Using Structs to Structure Related Data
+
+In Move, a `struct` groups related fields into a single type. Structs are the primary way to define custom data types and to model both ephemeral values and on-chain resources. Each struct definition lives inside a module and is either published on-chain or used purely off-chain.
+
+The following sections cover how to define structs, how abilities affect their behavior, how annotations group resources, and how to construct and deconstruct values.

--- a/src/structs/resources.md
+++ b/src/structs/resources.md
@@ -1,10 +1,10 @@
 # Structs and How They Become Resources
 
-When a struct declares the `key` ability, it can live in global storage at an account or object address. Storing such a value requires the `move_to` primitive and later access uses `borrow_global` or `move_from`:
+When a struct declares the `key` ability, it can live in global storage at an account or object address. Storing such a value requires the `move_to` primitive and later access uses `borrow_global`, `&[]` or `move_from`:
 
 ```move
 move_to(account, Balance { amount: 10 });
-let bal = borrow_global<Balance>(addr);
+let bal = &Balance[addr];
 ```
 
 On Aptos, related resources can be grouped together so they occupy a single storage slot. The group container is annotated with `#[resource_group]` and each member is annotated with `#[resource_group_member(group = <GroupStruct>)]`:
@@ -19,4 +19,4 @@ struct Wallet has key {
 struct Balance has key { amount: u64 }
 ```
 
-Placing `Balance` inside the `Wallet` resource group reduces storage overhead and lets the members be loaded together.
+Placing `Balance` inside the `Wallet` resource group has a trade off on storage costs and lets the members be loaded together in a single storage slot.  The most common example is 0x1::object::ObjectGroup

--- a/src/structs/resources.md
+++ b/src/structs/resources.md
@@ -1,1 +1,22 @@
 # Structs and How They Become Resources
+
+When a struct declares the `key` ability, it can live in global storage at an account or object address. Storing such a value requires the `move_to` primitive and later access uses `borrow_global` or `move_from`:
+
+```move
+move_to(account, Balance { amount: 10 });
+let bal = borrow_global<Balance>(addr);
+```
+
+On Aptos, related resources can be grouped together so they occupy a single storage slot. The group container is annotated with `#[resource_group]` and each member is annotated with `#[resource_group_member(group = <GroupStruct>)]`:
+
+```move
+#[resource_group]
+struct Wallet has key {
+    balance: Balance,
+}
+
+#[resource_group_member(group = Wallet)]
+struct Balance has key { amount: u64 }
+```
+
+Placing `Balance` inside the `Wallet` resource group reduces storage overhead and lets the members be loaded together.


### PR DESCRIPTION
## Summary
- document how to define and instantiate structs, including abilities and resource group annotations
- add examples showing construction, deconstruction, and grouping of resources
- expand enum chapter with definitions, pattern matching, and upgrade-friendly design
- remove unsupported `public` keyword from struct definitions

## Testing
- `mdbook build` *(fails: command not found: mdbook)*
- `apt-get install -y mdbook` *(fails: Unable to locate package mdbook)*

------
https://chatgpt.com/codex/tasks/task_b_6896b7786e0c8320bc52bd74f99cdb03